### PR TITLE
Content pass over the document

### DIFF
--- a/draft-iab-ip-geo-workshop-report.md
+++ b/draft-iab-ip-geo-workshop-report.md
@@ -842,4 +842,4 @@ Warren Kumari, Jason Livingood, and Tommy Pauly.
 # Acknowledgments
 {:numbered="false"}
 
-TODO Acks
+Thanks to all of the workshop participants who attended and contributed papers to this effort!


### PR DESCRIPTION
This is a pass (by a human!) to take the notes and transcripts from the workshop report and add them in.

I'll plan to just merge this and we'll take edits are further PRs as needed.